### PR TITLE
fix: robust import

### DIFF
--- a/bsz-nodes/__init__.py
+++ b/bsz-nodes/__init__.py
@@ -11,5 +11,5 @@ for finder in pkgutil.iter_modules(__path__):
         spec.loader.exec_module(mod)
         NODE_CLASS_MAPPINGS |= mod.NODE_CLASS_MAPPINGS
         NODE_DISPLAY_NAME_MAPPINGS |= mod.NODE_DISPLAY_NAME_MAPPINGS
-    except ImportError:
-        pass
+    except Exception:
+        print(f"[ERROR] bsz-cui-extras: Failed to load '{finder.name}' module")

--- a/bsz-nodes/bsz-pixelbuster.py
+++ b/bsz-nodes/bsz-pixelbuster.py
@@ -10,7 +10,12 @@ from sys import platform
 LIBRARY = {"win32": "pixelbuster.dll", "linux": "libpixelbuster.so"}
 import os.path
 
-pb_lib = ctypes.CDLL(os.path.join(os.path.dirname(os.path.realpath(__file__)), LIBRARY.get(platform)))
+pb_lib = None
+try:
+    pb_lib = ctypes.CDLL(os.path.join(os.path.dirname(os.path.realpath(__file__)), LIBRARY.get(platform)))
+except Exception as e:
+    print(f"[ERROR] bsz-cui-extras: Installation of the '{LIBRARY.get(platform)}' file is required.")
+    raise e
 
 pb_lib.pb_help_ffi.restype = ctypes.c_char_p
 HELP = pb_lib.pb_help_ffi().decode('UTF-8')


### PR DESCRIPTION
In the `bsz-pixelbuster.py` file, when there is no .so or .dll present, the import is executed. 
However, if a different exception occurs other than `ImportError`, the loading of the entire module fails. 
This is a patch to prevent that.